### PR TITLE
Improve login UX with theming

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,9 +3,14 @@
   line-height: 1.5;
   font-weight: 400;
 
+  /* Theme variables */
+  --bg-color: skyblue;
+  --text-color: #213547;
+  --button-bg: #1a1a1a;
+
   color-scheme: light;
-  color: #213547;
-  background-color: skyblue;
+  color: var(--text-color);
+  background-color: var(--bg-color);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -28,6 +33,8 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background-color: var(--bg-color);
+  color: var(--text-color);
 }
 
 h1 {
@@ -42,7 +49,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--button-bg);
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -52,6 +59,29 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
+}
+
+/* Dark theme */
+body.dark {
+  --bg-color: #1e1e1e;
+  --text-color: #f0f0f0;
+  --button-bg: #333;
+}
+
+/* Login layout */
+.login-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 300px;
+  margin: auto;
+  padding: 2rem;
+  background-color: rgba(255, 255, 255, 0.8);
+  border-radius: 8px;
+}
+
+body.dark .login-container {
+  background-color: rgba(0, 0, 0, 0.3);
 }
 
 @media (prefers-color-scheme: light) {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { useState, type ChangeEvent } from 'react'
+import { useState, useEffect, type ChangeEvent } from 'react'
 
 type Props = {
   onLogin: (user: string) => void
@@ -7,6 +7,12 @@ type Props = {
 export default function Login({ onLogin }: Props) {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [dark, setDark] = useState(false)
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', dark)
+  }, [dark])
 
   const submit = () => {
     if (username) {
@@ -17,7 +23,7 @@ export default function Login({ onLogin }: Props) {
   }
 
   return (
-    <div>
+    <div className="login-container">
       <h2>Login</h2>
       <input
         placeholder="User"
@@ -26,15 +32,32 @@ export default function Login({ onLogin }: Props) {
           setUsername(e.target.value)
         }
       />
-      <input
-        placeholder="Password"
-        type="password"
-        value={password}
-        onChange={(e: ChangeEvent<HTMLInputElement>) =>
-          setPassword(e.target.value)
-        }
-      />
-      <button onClick={submit}>Login</button>
+      <div>
+        <input
+          placeholder="Password"
+          type={showPassword ? 'text' : 'password'}
+          value={password}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setPassword(e.target.value)
+          }
+        />
+        <label style={{ marginLeft: '0.5rem' }}>
+          <input
+            type="checkbox"
+            checked={showPassword}
+            onChange={() => setShowPassword(!showPassword)}
+          />
+          Show
+        </label>
+      </div>
+      <div>
+        <button onClick={submit} style={{ marginRight: '0.5rem' }}>
+          Login
+        </button>
+        <button type="button" onClick={() => setDark(!dark)}>
+          {dark ? 'Light' : 'Dark'} Mode
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- implement dark/light theme toggler and show password option for the login page
- add login page styles and variables for theme colours

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685988a6943c83219d65f1bd849cd50f