### PR TITLE
Add chat tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import Login from './pages/Login'
+import Home from './pages/Home'
 import Dashboard from './pages/Dashboard'
 import './App.css'
 
@@ -10,12 +10,12 @@ export default function App() {
   return (
     <BrowserRouter basename="/invoice/management">
       <Routes>
-        <Route path="/login" element={<Login onLogin={setUser} />} />
+        <Route path="/" element={<Home onLogin={setUser} />} />
         <Route
           path="/dashboard"
-          element={user ? <Dashboard user={user} /> : <Navigate to="/login" replace />}
+          element={user ? <Dashboard user={user} /> : <Navigate to="/" replace />}
         />
-        <Route path="*" element={<Navigate to={user ? '/dashboard' : '/login'} replace />} />
+        <Route path="*" element={<Navigate to={user ? '/dashboard' : '/'} replace />} />
       </Routes>
     </BrowserRouter>
   )

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+
+interface Msg {
+  sender: 'user' | 'bot'
+  text: string
+}
+
+export default function Chat() {
+  const [messages, setMessages] = useState<Msg[]>([])
+  const [input, setInput] = useState('')
+
+  const send = async () => {
+    if (!input.trim()) return
+    const userMsg = { sender: 'user', text: input }
+    setMessages((m) => [...m, userMsg])
+    setInput('')
+    try {
+      const resp = await fetch('http://localhost:8080/api/chat', {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ message: userMsg.text }),
+      })
+      const data = await resp.json()
+      const botText = data.message ?? data.reply ?? JSON.stringify(data)
+      setMessages((m) => [...m, { sender: 'bot', text: botText }])
+    } catch (err) {
+      setMessages((m) => [...m, { sender: 'bot', text: 'Error sending message' }])
+    }
+  }
+
+  return (
+    <div className="p-4 max-w-xl mx-auto flex flex-col h-[70vh] border rounded bg-white/90">
+      <div className="flex-1 overflow-y-auto mb-2">
+        {messages.map((msg, idx) => (
+          <div key={idx} className={`my-1 ${msg.sender === 'user' ? 'text-right' : 'text-left'}`}>
+            <span className="inline-block p-2 rounded bg-gray-100">
+              {msg.text}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="flex space-x-2">
+        <input
+          className="flex-1 border rounded p-2"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') send()
+          }}
+          placeholder="Type a message..."
+        />
+        <button className="px-4 bg-[#1F4C3B] text-white rounded" onClick={send}>
+          Send
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react'
+import Login from './Login'
+import Chat from './Chat'
+
+interface Props {
+  onLogin: (user: string) => void
+}
+
+export default function Home({ onLogin }: Props) {
+  const [tab, setTab] = useState<'login' | 'chat'>('login')
+
+  return (
+    <div className="min-h-screen flex flex-col items-center p-4">
+      <div className="mb-4 space-x-2">
+        <button
+          onClick={() => setTab('login')}
+          className={`px-4 py-2 rounded ${
+            tab === 'login' ? 'bg-[#1F4C3B] text-white' : 'bg-gray-200'
+          }`}
+        >
+          Login
+        </button>
+        <button
+          onClick={() => setTab('chat')}
+          className={`px-4 py-2 rounded ${
+            tab === 'chat' ? 'bg-[#1F4C3B] text-white' : 'bg-gray-200'
+          }`}
+        >
+          Chat
+        </button>
+      </div>
+      <div className="w-full flex-1">
+        {tab === 'login' ? <Login onLogin={onLogin} /> : <Chat />}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Chat component with fetch to `/api/chat`
- add Home page with Login and Chat tabs
- update routing to show tabs on home page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6877fc4bb3d4832180564c6ca0ab7a71