### PR TITLE
Add animated layout and chat switcher

### DIFF
--- a/src/components/FinanceBackground.tsx
+++ b/src/components/FinanceBackground.tsx
@@ -1,3 +1,5 @@
+import { motion } from 'framer-motion'
+
 export default function FinanceBackground() {
   return (
     <div className="absolute inset-0 overflow-hidden pointer-events-none">
@@ -5,26 +7,52 @@ export default function FinanceBackground() {
       <div className="absolute inset-0 bg-grid-dots z-0" />
 
       {/* Floating Blobs */}
-      <div className="absolute -left-20 top-10 w-72 h-72 rounded-full bg-green-300 opacity-30 blur-3xl animate-float z-0" />
-      <div className="absolute right-0 bottom-0 w-96 h-96 rounded-full bg-yellow-200 opacity-30 blur-3xl animate-float [animation-duration:12s] z-0" />
+      <motion.div
+        className="absolute -left-20 top-10 w-72 h-72 rounded-full bg-green-300 opacity-30 blur-3xl z-0"
+        animate={{ y: [0, -30, 0] }}
+        transition={{ duration: 8, repeat: Infinity, ease: 'easeInOut' }}
+      />
+      <motion.div
+        className="absolute right-0 bottom-0 w-96 h-96 rounded-full bg-yellow-200 opacity-30 blur-3xl z-0"
+        animate={{ y: [0, -40, 0] }}
+        transition={{ duration: 12, repeat: Infinity, ease: 'easeInOut' }}
+      />
 
       {/* Floating Finance Icons */}
       <div className="absolute inset-0 flex items-end justify-center gap-10 pb-6 z-0">
-        <svg className="w-10 h-10 text-green-600 dark:text-green-400" viewBox="0 0 24 24" aria-hidden="true">
+        <motion.svg
+          className="w-10 h-10 text-green-600 dark:text-green-400"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          animate={{ y: [0, -10, 0] }}
+          transition={{ duration: 4, repeat: Infinity, ease: 'easeInOut' }}
+        >
           <title>Invoice</title>
           <path d="M6 2h7l5 5v15H6V2z" fill="currentColor" />
           <path d="M9 12h6M9 16h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-        </svg>
-        <svg className="w-10 h-10 text-blue-500 dark:text-blue-300" viewBox="0 0 24 24" aria-hidden="true">
+        </motion.svg>
+        <motion.svg
+          className="w-10 h-10 text-blue-500 dark:text-blue-300"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          animate={{ y: [0, -15, 0] }}
+          transition={{ duration: 5, repeat: Infinity, ease: 'easeInOut', delay: 0.2 }}
+        >
           <title>Chart</title>
           <rect x="4" y="10" width="3" height="10" rx="1" />
           <rect x="10" y="6" width="3" height="14" rx="1" />
           <rect x="16" y="13" width="3" height="7" rx="1" />
-        </svg>
-        <svg className="w-10 h-10 text-purple-500 dark:text-purple-400" viewBox="0 0 24 24" aria-hidden="true">
+        </motion.svg>
+        <motion.svg
+          className="w-10 h-10 text-purple-500 dark:text-purple-400"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          animate={{ y: [0, -8, 0] }}
+          transition={{ duration: 4.5, repeat: Infinity, ease: 'easeInOut', delay: 0.4 }}
+        >
           <title>Currency</title>
           <path d="M12 3v18M8 7h8a3 3 0 010 6H8m0 0h8a3 3 0 010 6H8" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-        </svg>
+        </motion.svg>
       </div>
     </div>
   )

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react'
+import FinanceBackground from './FinanceBackground'
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div className="relative min-h-screen flex items-center justify-center bg-gradient-to-br from-[#F9FAF8] via-[#E8F0EA] to-[#D8E3DC] p-4 overflow-hidden font-['Poppins','Inter',sans-serif]">
+      <FinanceBackground />
+      <div className="absolute inset-0 bg-gradient-to-b from-white/70 to-transparent pointer-events-none z-0" />
+      {children}
+    </div>
+  )
+}

--- a/src/components/LoginChatSwitcher.tsx
+++ b/src/components/LoginChatSwitcher.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import Login from '../pages/Login'
+import Chat from '../pages/Chat'
+
+interface Props {
+  onLogin: (user: string) => void
+}
+
+export default function LoginChatSwitcher({ onLogin }: Props) {
+  const [tab, setTab] = useState<'login' | 'chat'>('login')
+
+  return (
+    <div className="relative w-full max-w-4xl flex items-center justify-center">
+      <button
+        onClick={() => setTab('login')}
+        className={`px-4 py-2 rounded shadow-md backdrop-blur-md bg-white/80 transition-all ${tab === 'login' ? 'bg-primary text-white' : ''} ${tab ? 'absolute top-4 left-4' : 'mx-2'}`}
+      >
+        Login
+      </button>
+      <button
+        onClick={() => setTab('chat')}
+        className={`px-4 py-2 rounded shadow-md backdrop-blur-md bg-white/80 transition-all ${tab === 'chat' ? 'bg-primary text-white' : ''} ${tab ? 'absolute top-4 right-4' : 'mx-2'}`}
+      >
+        Chat
+      </button>
+      <div className="w-full flex justify-center mt-10">
+        <AnimatePresence mode="wait">
+          {tab === 'login' && (
+            <motion.div
+              key="login"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 20 }}
+              className="w-full"
+            >
+              <Login onLogin={onLogin} embedded />
+            </motion.div>
+          )}
+          {tab === 'chat' && (
+            <motion.div
+              key="chat"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 20 }}
+              className="w-full"
+            >
+              <Chat embedded />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
-import { motion } from 'framer-motion'
-import FinanceBackground from '../components/FinanceBackground'
+import { AnimatePresence, motion } from 'framer-motion'
+import Layout from '../components/Layout'
 
 interface Msg {
   sender: 'user' | 'bot'
@@ -74,18 +74,21 @@ export default function Chat({ embedded = false }: Props) {
       className="bg-white/90 backdrop-blur-sm shadow-xl rounded-xl p-6 w-full max-w-xl flex flex-col h-[70vh]"
     >
       <div className="flex-1 overflow-y-auto mb-2">
-        {messages.map((msg, idx) => (
-          <motion.div
-            key={idx}
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            className={`my-1 ${msg.sender === 'user' ? 'text-right' : 'text-left'}`}
-          >
-            <span className="inline-block p-2 rounded bg-gray-100">
-              {msg.text}
-            </span>
-          </motion.div>
-        ))}
+        <AnimatePresence initial={false}>
+          {messages.map((msg, idx) => (
+            <motion.div
+              key={idx}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              className={`my-1 ${msg.sender === 'user' ? 'text-right' : 'text-left'}`}
+            >
+              <span className="inline-block p-2 rounded bg-gray-100">
+                {msg.text}
+              </span>
+            </motion.div>
+          ))}
+        </AnimatePresence>
         {loading && (
           <div className="my-1 text-left">
             <span className="inline-block p-2 rounded bg-gray-100">
@@ -126,10 +129,5 @@ export default function Chat({ embedded = false }: Props) {
     return panel
   }
 
-  return (
-    <div className="relative min-h-screen flex items-center justify-center bg-gradient-to-br from-[#F9FAF8] via-[#E8F0EA] to-[#D8E3DC] p-4 overflow-hidden font-['Poppins','Inter',sans-serif]">
-      <FinanceBackground />
-      {panel}
-    </div>
-  )
+  return <Layout>{panel}</Layout>
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,64 +1,14 @@
-import { useState } from 'react'
-import { AnimatePresence, motion } from 'framer-motion'
-import Login from './Login'
-import Chat from './Chat'
-import FinanceBackground from '../components/FinanceBackground'
+import Layout from '../components/Layout'
+import LoginChatSwitcher from '../components/LoginChatSwitcher'
 
 interface Props {
   readonly onLogin: (user: string) => void
 }
 
 export default function Home({ onLogin }: Props) {
-  const [tab, setTab] = useState<'login' | 'chat' | null>(null)
-
-  const toggleTab = (next: 'login' | 'chat') => {
-    setTab((current) => (current === next ? null : next))
-  }
   return (
-    <div className="relative min-h-screen flex items-center justify-center p-4 overflow-hidden">
-      <FinanceBackground />
-      <div className="relative w-full max-w-4xl flex items-center justify-center">
-        <button
-          onClick={() => toggleTab('login')}
-          className={`px-4 py-2 rounded shadow-md backdrop-blur-md bg-white/80 transition-all ${tab ? 'absolute top-4 left-4' : 'mx-2'
-            } ${tab === 'login' ? 'bg-primary text-white' : ''}`}
-        >
-          Login
-        </button>
-        <button
-          onClick={() => toggleTab('chat')}
-          className={`px-4 py-2 rounded shadow-md backdrop-blur-md bg-white/80 transition-all ${tab ? 'absolute top-4 right-4' : 'mx-2'
-            } ${tab === 'chat' ? 'bg-primary text-white' : ''}`}
-        >
-          Chat
-        </button>
-        <div className="w-full flex justify-center mt-10">
-          <AnimatePresence mode="wait">
-            {tab === 'login' && (
-              <motion.div
-                key="login"
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: 20 }}
-                className="w-full"
-              >
-                <Login onLogin={onLogin} embedded />
-              </motion.div>
-            )}
-            {tab === 'chat' && (
-              <motion.div
-                key="chat"
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: 20 }}
-                className="w-full"
-              >
-                <Chat embedded />
-              </motion.div>
-            )}
-          </AnimatePresence>
-        </div>
-      </div>
-    </div>
+    <Layout>
+      <LoginChatSwitcher onLogin={onLogin} />
+    </Layout>
   )
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import { useState, type ChangeEvent, type FormEvent } from 'react'
 import { motion } from 'framer-motion'
-import FinanceBackground from '../components/FinanceBackground'
+import Layout from '../components/Layout'
 
 type Props = {
   onLogin: (user: string) => void
@@ -175,10 +175,5 @@ export default function Login({ onLogin, embedded = false }: Props) {
     return card
   }
 
-  return (
-    <div className="relative min-h-screen flex items-center justify-center bg-gradient-to-br from-[#F9FAF8] via-[#E8F0EA] to-[#D8E3DC] p-4 overflow-hidden font-['Poppins','Inter',sans-serif]">
-      <FinanceBackground />
-      {card}
-    </div>
-  )
+  return <Layout>{card}</Layout>
 }


### PR DESCRIPTION
## Summary
- create Layout wrapper for shared background
- animate background elements with Framer Motion
- add LoginChatSwitcher component for toggling chat and login
- update pages to use Layout and new switcher
- add entry/exit animations to chat messages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68781a0950b483218ae9c4d0ac550822