### PR TITLE
Use FinanceBackground globally

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import Home from './pages/Home'
 import Dashboard from './pages/Dashboard'
+import Layout from './components/Layout'
 import './App.css'
 
 export default function App() {
@@ -9,14 +10,16 @@ export default function App() {
 
   return (
     <BrowserRouter basename="/invoice/management">
-      <Routes>
-        <Route path="/" element={<Home onLogin={setUser} />} />
-        <Route
-          path="/dashboard"
-          element={user ? <Dashboard user={user} /> : <Navigate to="/" replace />}
-        />
-        <Route path="*" element={<Navigate to={user ? '/dashboard' : '/'} replace />} />
-      </Routes>
+      <Layout>
+        <Routes>
+          <Route path="/" element={<Home onLogin={setUser} />} />
+          <Route
+            path="/dashboard"
+            element={user ? <Dashboard user={user} /> : <Navigate to="/" replace />}
+          />
+          <Route path="*" element={<Navigate to={user ? '/dashboard' : '/'} replace />} />
+        </Routes>
+      </Layout>
     </BrowserRouter>
   )
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,14 +9,8 @@ const Chat = dynamic(() => import('../components/Chat'))
 export default function Home() {
   const [tab, setTab] = useState<'none' | 'login' | 'chat'>('none')
 
-  const backgroundStyle = {
-    backgroundImage: "url('https://images.unsplash.com/photo-1521791136064-7986c2920216')",
-    backgroundSize: 'cover',
-    backgroundPosition: 'center',
-  }
-
   return (
-    <div className="w-full h-screen flex items-center justify-center relative" style={backgroundStyle}>
+    <div className="w-full h-screen flex items-center justify-center relative">
       {tab === 'none' && (
         <motion.div
           className="flex space-x-6"


### PR DESCRIPTION
## Summary
- wrap the app routes with `Layout` so `FinanceBackground` is included on every page
- remove the old Unsplash-based background from the home page

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: cannot find module 'react' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68782cb0aa2c8321866f92b8760994b5