### PR TITLE
Use icon components instead of emoji

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import ReactMarkdown from 'react-markdown'
 import { AiOutlineCloseCircle } from 'react-icons/ai'
+import { FaRobot, FaUser, FaTrash } from 'react-icons/fa'
 
 interface Message {
   sender: 'user' | 'bot'
@@ -172,7 +173,7 @@ export default function Chat({ onClose }: Props) {
               >
                 {msg.sender === 'bot' && (
                   <div className="w-8 h-8 rounded-full bg-blue-500 text-white flex items-center justify-center font-semibold text-sm">
-                    🤖
+                    <FaRobot />
                   </div>
                 )}
                 <div>
@@ -193,7 +194,7 @@ export default function Chat({ onClose }: Props) {
                 </div>
                 {msg.sender === 'user' && (
                   <div className="w-8 h-8 rounded-full bg-green-500 text-white flex items-center justify-center font-semibold text-sm">
-                    🧑
+                    <FaUser />
                   </div>
                 )}
               </motion.div>
@@ -208,7 +209,7 @@ export default function Chat({ onClose }: Props) {
                 className="flex items-start gap-2"
               >
                 <div className="w-8 h-8 rounded-full bg-blue-500 text-white flex items-center justify-center font-semibold text-sm">
-                  🤖
+                  <FaRobot />
                 </div>
                 <div className="max-w-xs px-4 py-2 rounded-lg text-sm bg-white dark:bg-gray-600 text-gray-900 dark:text-white font-mono whitespace-pre-wrap">
                   {streamingBotMessage}
@@ -239,7 +240,7 @@ export default function Chat({ onClose }: Props) {
             className="px-3 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600"
             title="Clear chat"
           >
-            🗑️
+            <FaTrash />
           </button>
         </div>
       </motion.div>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -2,6 +2,7 @@ import { useState, type ChangeEvent, type FormEvent } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { FiEye, FiEyeOff } from 'react-icons/fi'
 import { AiOutlineCloseCircle } from 'react-icons/ai'
+import { FaGoogle, FaGithub, FaFacebook } from 'react-icons/fa'
 
 type Props = {
   onLogin: (user: string) => void
@@ -160,17 +161,23 @@ export default function Login({ onLogin, isVisible = true, onClose }: Props) {
                   },
                 }}
               >
-                {['Google', 'GitHub', 'Facebook'].map((provider) => (
+                {(
+                  [
+                    { name: 'Google', icon: <FaGoogle size={20} /> },
+                    { name: 'GitHub', icon: <FaGithub size={20} /> },
+                    { name: 'Facebook', icon: <FaFacebook size={20} /> },
+                  ] as const
+                ).map((provider) => (
                   <motion.button
-                    key={provider}
+                    key={provider.name}
                     type="button"
-                    aria-label={`Login with ${provider}`}
+                    aria-label={`Login with ${provider.name}`}
                     whileHover={{ scale: 1.1 }}
                     whileTap={{ scale: 0.95 }}
                     variants={{ hidden: { opacity: 0, y: 8 }, visible: { opacity: 1, y: 0 } }}
                     className="w-10 h-10 rounded-full border flex items-center justify-center text-gray-600 hover:bg-gray-100"
                   >
-                    <span className="text-sm font-bold">{provider[0]}</span>
+                    {provider.icon}
                   </motion.button>
                 ))}
               </motion.div>


### PR DESCRIPTION
## Summary
- swap emoji icons for Font Awesome icons in chat dialog
- show social login icons instead of text in the login modal

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6878302120d883219d6530a99fa69b43